### PR TITLE
解决github.com/google/martian/log导入异常

### DIFF
--- a/engine/gengine.go
+++ b/engine/gengine.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 )
 
 type Gengine struct {

--- a/engine/gengine_pool.go
+++ b/engine/gengine_pool.go
@@ -12,7 +12,7 @@ import (
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"sync"
 
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 )
 
 const (
@@ -384,7 +384,7 @@ func (gp *GenginePool) ClearPoolRules() {
 	defer gp.updateLock.Unlock()
 	gp.ruleBuilder = nil
 	gp.clear = true
-	for i := 0; i < int(gp.max) ; i++ {
+	for i := 0; i < int(gp.max); i++ {
 		gp.rbSlice[i].Kc.ClearRules()
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module gengine
 
-go 1.13
+go 1.15
 
 require (
-	github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f
+	github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
-	github.com/google/martian v2.1.0+incompatible
+	github.com/google/martian/v3 v3.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
-github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f h1:0cEys61Sr2hUBEXfNV8eyQP01oZuBgoMeHunebPirK8=
-github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
+github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113 h1:+Je12tQpLUUQEfMUrLkTPXe1wh8VXCPjFsdwY29co30=
+github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 h1:zN2lZNZRflqFyxVaTIU61KNKQ9C0055u9CAfpmqUvo4=
 github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3/go.mod h1:nPpo7qLxd6XL3hWJG/O60sR8ZKfMCiIoNap5GvD12KU=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
-github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/martian/v3 v3.1.0 h1:wCKgOCHuUEVfsaQLpPSJb7VdYCdTVZQAuOdYm1yc/60=
+github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/base/conc_statement.go
+++ b/internal/base/conc_statement.go
@@ -2,7 +2,7 @@ package base
 
 import (
 	"gengine/context"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 	"sync"
 )
 

--- a/test/at_desc_test.go
+++ b/test/at_desc_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 )
 
 /**

--- a/test/at_name_test.go
+++ b/test/at_name_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 	"testing"
 	"time"
 )

--- a/test/complex/extends_test.go
+++ b/test/complex/extends_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/complex/set_test.go
+++ b/test/complex/set_test.go
@@ -4,7 +4,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/conc_statement_test.go
+++ b/test/conc_statement_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/concurrent/concurrent_test.go
+++ b/test/concurrent/concurrent_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"io/ioutil"
 	"os"

--- a/test/else_if_test.go
+++ b/test/else_if_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/exceute_selected_rules_test.go
+++ b/test/exceute_selected_rules_test.go
@@ -4,7 +4,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/gengine_base_test.go
+++ b/test/gengine_base_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/gengine_salience_test.go
+++ b/test/gengine_salience_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/grammar_test.go
+++ b/test/grammar_test.go
@@ -8,7 +8,7 @@ import (
 	parser "gengine/internal/iantlr/alr"
 	"gengine/internal/iparser"
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 )

--- a/test/map_slice_array/array_test.go
+++ b/test/map_slice_array/array_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/map_slice_array/gengine_map_array_test.go
+++ b/test/map_slice_array/gengine_map_array_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/map_slice_array/map_test.go
+++ b/test/map_slice_array/map_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/map_slice_array/slice_test.go
+++ b/test/map_slice_array/slice_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/math/num_test.go
+++ b/test/math/num_test.go
@@ -4,7 +4,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/math/type_test.go
+++ b/test/math/type_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/mutli_rules_test.go
+++ b/test/mutli_rules_test.go
@@ -6,7 +6,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"io/ioutil"
 	"strconv"

--- a/test/not_test.go
+++ b/test/not_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"

--- a/test/struct_test.go
+++ b/test/struct_test.go
@@ -5,7 +5,7 @@ import (
 	"gengine/builder"
 	"gengine/context"
 	"gengine/engine"
-	"github.com/google/martian/log"
+	"github.com/google/martian/v3/log"
 
 	"testing"
 	"time"


### PR DESCRIPTION
go mod tidy时会报错，用github.com/google/martian/v3/log替代github.com/google/martian/log